### PR TITLE
Add lucide-react dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "date-fns": "^4.1.0",
         "discord-api-types": "^0.38.0",
         "kofi-button": "^1.1.1",
+        "lucide-react": "^0.539.0",
         "material-react-table": "^3.2.1",
         "next": "^15.2.0",
         "particles-bg": "^2.5.5",
@@ -9118,6 +9119,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.539.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.539.0.tgz",
+      "integrity": "sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/material-react-table": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "date-fns": "^4.1.0",
     "discord-api-types": "^0.38.0",
     "kofi-button": "^1.1.1",
+    "lucide-react": "^0.539.0",
     "material-react-table": "^3.2.1",
     "next": "^15.2.0",
     "particles-bg": "^2.5.5",


### PR DESCRIPTION
Added lucide-react version 0.539.0 to package.json for icon support in the project. This should help replace some of the icons with a Lucide's CDN instead of having to deliver server side images